### PR TITLE
Add tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = linters
+skipsdist = True
+
+[testenv]
+deps =
+  -rtest-requirements.txt
+  -raws/requirements.txt
+  -raws/test-requirements.txt
+  -rhacking/requirements.txt
+  -rhacking/test-requirements.txt
+install_command = pip install -c constraints.txt {opts} {packages}
+
+[testenv:linters]
+basepython = python3.7
+allowlist_externals = make
+commands = make test-all PYTHON3={envpython}


### PR DESCRIPTION
This adds a tox environment to run the existing test-all make target.
There's a bit better isolation when running locally, and the zuul config
is easier since we already have tox jobs available.