### PR TITLE
Update age limit and ignore Persistent resources

### DIFF
--- a/aws/terminator/__init__.py
+++ b/aws/terminator/__init__.py
@@ -186,7 +186,7 @@ class Terminator(abc.ABC):
 
     @property
     def age_limit(self) -> datetime.timedelta:
-        return datetime.timedelta(minutes=20)
+        return datetime.timedelta(days=7)
 
     @property
     def id(self) -> typing.Optional[str]:

--- a/aws/terminator/__init__.py
+++ b/aws/terminator/__init__.py
@@ -264,7 +264,7 @@ class Terminator(abc.ABC):
     def is_persistent(self) -> bool:
         try:
             return get_tag_dict_from_tag_list(self.instance.get('Tags')).get('Persistent', 'false').lower() == 'true'
-        except:
+        except Exception:  # pylint: disable=broad-except
             return False
 
 

--- a/aws/terminator/__init__.py
+++ b/aws/terminator/__init__.py
@@ -51,7 +51,9 @@ def cleanup(check: bool, force: bool, targets: typing.Optional[typing.List[str]]
 
 
 def process_instance(instance: 'Terminator', check: bool, force: bool = False) -> str:
-    if instance.ignore:
+    if instance.is_persistent():
+        status = 'persistent'
+    elif instance.ignore:
         status = 'ignored'
     elif force:
         status = terminate(instance, check)
@@ -258,6 +260,12 @@ class Terminator(abc.ABC):
 
     def is_vpc_default(self, vpc_id: str) -> bool:
         return self.default_vpc.get('VpcId') == vpc_id
+
+    def is_persistent(self) -> bool:
+        try:
+            return get_tag_dict_from_tag_list(self.instance.get('Tags')).get('Persistent', 'false').lower() == 'true'
+        except:
+            return False
 
 
 class DbTerminator(Terminator):

--- a/aws/terminator/compute.py
+++ b/aws/terminator/compute.py
@@ -123,7 +123,7 @@ class Ec2Volume(Terminator):
 
     @property
     def age_limit(self):
-        return datetime.timedelta(minutes=15)
+        return datetime.timedelta(days=7)
 
     @property
     def id(self):

--- a/aws/terminator/data_services.py
+++ b/aws/terminator/data_services.py
@@ -262,7 +262,7 @@ class RdsDbCluster(Terminator):
 
     @property
     def age_limit(self):
-        return datetime.timedelta(minutes=60)
+        return datetime.timedelta(days=7)
 
     @property
     def created_time(self):

--- a/aws/terminator/networking.py
+++ b/aws/terminator/networking.py
@@ -147,7 +147,7 @@ class Ec2InternetGateway(DbTerminator):
 
     @property
     def age_limit(self):
-        return datetime.timedelta(minutes=25)
+        return datetime.timedelta(days=7)
 
     @property
     def id(self):


### PR DESCRIPTION

- Delete only resources that are 7 days or older (The age limit has been increased for the following resources: RdsDbCluster, Ec2Volume, Ec2Snapshot, Ec2Instance, Ec2Eip, Ec2NatGateway, Ec2InternetGateway)
- Ignore resources that have been tagged with "Persistent: True"