### PR TITLE
add linters workflow

### DIFF
--- a/.github/workflow/linters.yml
+++ b/.github/workflow/linters.yml
@@ -1,0 +1,8 @@
+name: linters
+
+on:
+  pull_request:
+
+jobs:
+  linters:
+    uses: ansible-network/github_actions/.github/workflows/tox-linters.yml@main


### PR DESCRIPTION
The linters workflow previously running on Zuul has been removed here https://github.com/ansible/zuul-config/pull/637
This PR adds the same workflow on GitHub Actions